### PR TITLE
Minor patches to the MMD Test Suite

### DIFF
--- a/MarkdownTest.pl
+++ b/MarkdownTest.pl
@@ -78,7 +78,17 @@ foreach my $testfile (glob "$test_dir/*.text") {
 		$t_result =~ s{'}{'\\''}g; # escape ' chars for shell
 		$t_output =~ s{'}{'\\''}g;
 		$t_result = `echo '$t_result' | tidy --show-body-only 1 --quiet 1 --show-warnings 0`;
+		if ($?) {
+			print "'$testfile' running tidy failed.\n\n";
+			$tests_failed++;
+			next TEST;
+		}
 		$t_output = `echo '$t_output' | tidy --show-body-only 1 --quiet 1 --show-warnings 0`;
+		if ($?) {
+			print "'$testfile' running tidy failed.\n\n";
+			$tests_failed++;
+			next TEST;
+		}
 	}
 
 	if ($t_output eq $t_result) {


### PR DESCRIPTION
Mostly these are about making sure tests fail and fail with a non-zero exit code when appropriate.

There is also a commit about unsafe diff on open file handles, and one about consistent tab-based indentation.
