### PR TITLE
"Must Start With Alpha" -> "Can Start With Digit".

### DIFF
--- a/MultiMarkdownTests/Automatic Labels.fodt
+++ b/MultiMarkdownTests/Automatic Labels.fodt
@@ -270,6 +270,10 @@
 
 <text:p text:style-name="Standard">And now, link to <text:a xlink:type="simple" xlink:href="#1cross-references:specialcharacters">1 Cross-References: Special Characters!@#$%&amp;*()&lt;&gt;^</text:a></text:p>
 
+<text:h text:outline-level="2"><text:bookmark text:name="Заголовокпо-русски"/>Заголовок по-русски<text:bookmark-end text:name="Заголовокпо-русски"/></text:h>
+
+<text:p text:style-name="Standard">И ссылка на <text:a xlink:type="simple" xlink:href="#Заголовокпо-русски">Заголовок по-русски</text:a>.</text:p>
+
 <text:h text:outline-level="2"><text:bookmark text:name="setext1"/>Setext 1<text:bookmark-end text:name="setext1"/></text:h>
 
 <text:h text:outline-level="3"><text:bookmark text:name="setext2"/>Setext 2<text:bookmark-end text:name="setext2"/></text:h>

--- a/MultiMarkdownTests/Automatic Labels.html
+++ b/MultiMarkdownTests/Automatic Labels.html
@@ -19,6 +19,10 @@
 
 <p>And now, link to <a href="#1cross-references:specialcharacters">1 Cross-References: Special Characters!@#$%&amp;*()&lt;&gt;^</a></p>
 
+<h2 id="Заголовокпо-русски">Заголовок по-русски</h2>
+
+<p>И ссылка на <a href="#Заголовокпо-русски">Заголовок по-русски</a>.</p>
+
 <h2 id="setext1">Setext 1</h2>
 
 <h3 id="setext2">Setext 2</h3>

--- a/MultiMarkdownTests/Automatic Labels.opml
+++ b/MultiMarkdownTests/Automatic Labels.opml
@@ -6,6 +6,7 @@
 <outline text="Strip out &amp;%^ characters &amp;*^" _note=""></outline>
 <outline text="Special Cross Reference Cases" _note=""><outline text="1 Cross-References: Special Characters!@#$%&amp;*()&lt;&gt;^" _note="And now, link to [1 Cross-References: Special Characters!@#$%&amp;*()&lt;&gt;^][]&#10;"></outline>
 </outline>
+<outline text="Заголовок по-русски" _note="И ссылка на [Заголовок по-русски].&#10;"></outline>
 <outline text="Setext 1" _note=""><outline text="Setext 2" _note=""></outline>
 </outline>
 <outline text="Atx 1" _note="Link to [Setext 1].&#10;&#10;And [Setext 2].&#10;&#10;And [Atx 1].&#10;&#10;And [Atx 2] should fail.&#10;"></outline>

--- a/MultiMarkdownTests/Automatic Labels.tex
+++ b/MultiMarkdownTests/Automatic Labels.tex
@@ -16,6 +16,11 @@
 
 And now, link to 1 Cross-References: Special Characters!@\#\$\%\&*()$<$$>$\^{} (\autoref{1cross-references:specialcharacters})
 
+\chapter{Заголовок по-русски}
+\label{Заголовокпо-русски}
+
+И ссылка на Заголовок по-русски (\autoref{Заголовокпо-русски}).
+
 \chapter{Setext 1}
 \label{setext1}
 

--- a/MultiMarkdownTests/Automatic Labels.text
+++ b/MultiMarkdownTests/Automatic Labels.text
@@ -15,6 +15,9 @@ latex footer:	mmd-memoir-footer
 
 And now, link to [1 Cross-References: Special Characters!@#$%&*()<>^][]
 
+# Заголовок по-русски #
+
+И ссылка на [Заголовок по-русски].
 
 Setext 1
 ========


### PR DESCRIPTION
A test slightly updated: Now multimarkdown allows digits in labels,
so name "Must Start With Alpha" is not actual.
